### PR TITLE
knownSums should be empty array in case there is no matching entry

### DIFF
--- a/modules/audio.js
+++ b/modules/audio.js
@@ -287,7 +287,7 @@ export const audioHTML = ({ fp, note, modal, getDiffs, hashMini, hashSlice, perf
 			values
 		}
 	} = fp
-	const knownSums = getKnownAudio()[compressorGainReduction]
+	const knownSums = getKnownAudio()[compressorGainReduction] || []
 	const validAudio = sampleSum && compressorGainReduction && knownSums
 	const matchesKnownAudio = knownSums.includes(sampleSum)
 	return `


### PR DESCRIPTION
My browser has no matching gainFunction, so `knownSums` is `undefined` leading to a JS error. This defaults `knownSums` to be an empty array.