### PR TITLE
use `getOwnPropertyNames` to see if webdriver was changed

### DIFF
--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -85,6 +85,8 @@ export default async function getHeadlessFeatures({
 				webDriverIsOn: (
 					(CSS.supports('border-end-end-radius: initial') && navigator.webdriver === undefined) ||
 					!!navigator.webdriver
+					// Somehow this tells me some things that have been changed on `navigator` 
+					|| Object.getOwnPropertyNames(navigator).indexOf("webdriver") != -1
 				),
 				noChrome: IS_BLINK && !('chrome' in window),
 				hasPermissionsBug: (


### PR DESCRIPTION
Making the assumption that if the browser modified `navigator.webdriver` from its prototype; we're pretty safe in assuming its on.