### PR TITLE
Address #264: fix fonts.lied = undefined

### DIFF
--- a/src/fonts/index.ts
+++ b/src/fonts/index.ts
@@ -374,7 +374,7 @@ export default async function getFonts() {
 			lieProps['String.fromCodePoint'] ||
 			lieProps['CSSStyleDeclaration.setProperty'] ||
 			lieProps['CSS2Properties.setProperty']
-		)
+		) || false
 
 		if (isFontOSBad(USER_AGENT_OS, fontFaceLoadFonts)) {
 			LowerEntropy.FONTS = true,


### PR DESCRIPTION
Fixes the case when fonts.lied is undefined. It should be "false".