### PR TITLE
Use the range object for rangeBoundingClientRect

### DIFF
--- a/src/domrect/index.ts
+++ b/src/domrect/index.ts
@@ -252,7 +252,7 @@ export default async function getClientRects() {
 
 		const rangeBoundingClientRect = [...rectElems].map((el) => {
 			range.selectNode(el)
-			return toNativeObject(el.getBoundingClientRect())
+			return toNativeObject(range.getBoundingClientRect())
 		})
 
 		// detect failed shift calculation


### PR DESCRIPTION
`rangeBoundingClientRect` returns `el.getBoundingClientRect()` after `range.selectNode(el)`, so it duplicates `elementBoundingClientRect`. Now it returns `range.getBoundingClientRect()`, like the `rangeClientRects` array above it.

Fixes #273
